### PR TITLE
Adds method for resetting internal state of PagedLoadScrollListener

### DIFF
--- a/stickyheaders/src/main/java/org/zakariya/stickyheaders/PagedLoadScrollListener.java
+++ b/stickyheaders/src/main/java/org/zakariya/stickyheaders/PagedLoadScrollListener.java
@@ -79,6 +79,13 @@ public abstract class PagedLoadScrollListener extends RecyclerView.OnScrollListe
 			}
 		}
 	}
+	
+	public void resetPaging() {
+		currentPage = 0;
+		previousTotalItemCount = 0;
+		loading = false;
+		loadExhausted = false;
+	}
 
 	/**
 	 * Override this to handle loading of new data. Each time new data is pulled in, the page counter will increase by one.


### PR DESCRIPTION
This method is very useful if RecyclerView is inside SwipeRefreshLayout. Because if user reaches bottom of the list, developer should make call to `loadComplete.notifyLoadExhausted()` to indicate to PagedLoadScrollListener that we have loaded last items from data source. However if user do SwipeToRefresh action, `onLoadMore()` method will not be called because `loadExhausted` is set to `true`.

Workaround for developer would be to create new scroll listener. 

With `resetPaging()` developer will not need to create new instance of `PagedLoadScrollListener`, but just call `resetPaging()` method to reset internal state of `PagedLoadScrollListener`.